### PR TITLE
ISSUE-237: Align top + texts to stay in the grid

### DIFF
--- a/client/src/components/Property/DetailedInfo.js
+++ b/client/src/components/Property/DetailedInfo.js
@@ -197,7 +197,7 @@ const Wrapper = styled.div`
   border-radius: 15px;
   padding: 16px;
   width: 100%;
-  margin: -23px;
+  // margin: -23px;
   background-color: white;
   text-align: center;
   box-shadow: 10px 10px #fbe8e9;
@@ -215,7 +215,6 @@ const BoldHeader = styled.h2`
 `;
 
 const Box = styled.div`
-  padding: 20px;
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/client/src/components/Property/DetailedInfo.js
+++ b/client/src/components/Property/DetailedInfo.js
@@ -45,7 +45,7 @@ function DetailedInfo({ propertyDetails }) {
         }}
       >
         <Wrapper>
-          <Grid container spacing={20}>
+          <Grid container spacing={20} wrap="nowrap">
             <Grid item xs={12} sm={6}>
               <div
                 style={{
@@ -176,17 +176,6 @@ function DetailedInfo({ propertyDetails }) {
               </InfoRow>
             </StyledText>
           </div>
-          {/* <ThemeProvider theme={theme}> */}
-          {/* <Button
-            variant="outlined"
-            color="primary"
-            size="large"
-            endIcon={<ArrowForward />}
-            sx={{ backgroundColor: '#FFFFFF' }}
-          >
-            See More Facts and Features
-          </Button> */}
-          {/* </ThemeProvider> */}
         </Wrapper>
       </Box>
     </Container>
@@ -218,6 +207,7 @@ const Bold = styled.b`
   font-weight: bold;
   margin-top: 30px;
 `;
+
 const BoldHeader = styled.h2`
   font-weight: bold;
   font-size: 25px;

--- a/client/src/components/Property/MapBox.js
+++ b/client/src/components/Property/MapBox.js
@@ -34,7 +34,7 @@ function MapBox({ longitude, latitude }) {
       <div
         ref={mapContainer}
         style={{
-          width: '500px',
+          maxWidth: '500px',
           height: '400px',
           border: '1px solid #ccc',
         }}

--- a/client/src/pages/PropertyDetail/PropertyDetail.js
+++ b/client/src/pages/PropertyDetail/PropertyDetail.js
@@ -94,18 +94,16 @@ const HeaderWrapper = styled.div`
 const GraphicWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  padding: 20px 50px;
+  align-items: stretch;
   width: 100%;
-  justify-content: center;
 `;
 
 const ContentWrapper = styled.div`
   padding: 10px 50px;
   display: flex;
-  justify-content: space-around;
   align-items: stretch;
   margin: 0;
+  vertical-align: top;
 `;
 
 const Row = styled.div`


### PR DESCRIPTION
## :: Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Edit convention

<br />

## :: Description

- Align the top line
- Detailed info stays in the grid when shrunk

<br />
