### PR TITLE
ISSUE-246: add endpoint prefix 'api'

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -38,7 +38,6 @@
         "@babel/runtime": "^7.22.3",
         "@types/jest": "^29.5.3",
         "babel-loader": "^9.1.2",
-        "bcryptjs": "^2.4.3",
         "eslint": "^8.42.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.8.0",
@@ -178,22 +177,22 @@
       "optional": true
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.379.1.tgz",
-      "integrity": "sha512-aONC8IyC54OMcdoRCqI+Fw4VIIlonWmFdLDyZPfGoqwYpe/Vqz7DPF7s/ohqiZBSpEt2SzZeKHEpmkBPR8fpkw==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.382.0.tgz",
+      "integrity": "sha512-EgKpWh5w2uWNzjtcD3S3JLSuuwLvvaeaVih60xNEoyaxpqwgjAe0vw/8GT9q2nqhS0J+B3bQVYdkCyA5oQDVEQ==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.379.1",
-        "@aws-sdk/credential-provider-node": "3.379.1",
+        "@aws-sdk/client-sts": "3.382.0",
+        "@aws-sdk/credential-provider-node": "3.382.0",
         "@aws-sdk/middleware-host-header": "3.379.1",
         "@aws-sdk/middleware-logger": "3.378.0",
         "@aws-sdk/middleware-recursion-detection": "3.378.0",
         "@aws-sdk/middleware-signing": "3.379.1",
-        "@aws-sdk/middleware-user-agent": "3.379.1",
+        "@aws-sdk/middleware-user-agent": "3.382.0",
         "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.378.0",
+        "@aws-sdk/util-endpoints": "3.382.0",
         "@aws-sdk/util-user-agent-browser": "3.378.0",
         "@aws-sdk/util-user-agent-node": "3.378.0",
         "@smithy/config-resolver": "^2.0.1",
@@ -225,9 +224,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.379.1.tgz",
-      "integrity": "sha512-2N16TPnRcq+seNP8VY/Zq7kfnrUOrJMbVNpyDZWGe5Qglua3n8v/FzxmXFNI87MiSODq8IHtiXhggWhefCd+TA==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.382.0.tgz",
+      "integrity": "sha512-ge11t4hJllOF8pBNF0p1X52lLqUsLGAoey24fvk3fyvvczeLpegGYh2kdLG0iwFTDgRxaUqK+kboH5Wy9ux/pw==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -235,9 +234,9 @@
         "@aws-sdk/middleware-host-header": "3.379.1",
         "@aws-sdk/middleware-logger": "3.378.0",
         "@aws-sdk/middleware-recursion-detection": "3.378.0",
-        "@aws-sdk/middleware-user-agent": "3.379.1",
+        "@aws-sdk/middleware-user-agent": "3.382.0",
         "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.378.0",
+        "@aws-sdk/util-endpoints": "3.382.0",
         "@aws-sdk/util-user-agent-browser": "3.378.0",
         "@aws-sdk/util-user-agent-node": "3.378.0",
         "@smithy/config-resolver": "^2.0.1",
@@ -269,9 +268,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.379.1.tgz",
-      "integrity": "sha512-B6hZ2ysPyvafCMf6gls1jHI/IUviVZ4+TURpNfUBqThg/hZ1IMxc4BLkXca6VlgzYR+bWU8GKiClS9fFH6mu0g==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.382.0.tgz",
+      "integrity": "sha512-hTfvB1ftbrqaz7qiEkmRobzUQwG34oZlByobn8Frdr5ZQbJk969bX6evQAPyKlJEr26+kL9TnaX+rbLR/+gwHQ==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -279,9 +278,9 @@
         "@aws-sdk/middleware-host-header": "3.379.1",
         "@aws-sdk/middleware-logger": "3.378.0",
         "@aws-sdk/middleware-recursion-detection": "3.378.0",
-        "@aws-sdk/middleware-user-agent": "3.379.1",
+        "@aws-sdk/middleware-user-agent": "3.382.0",
         "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.378.0",
+        "@aws-sdk/util-endpoints": "3.382.0",
         "@aws-sdk/util-user-agent-browser": "3.378.0",
         "@aws-sdk/util-user-agent-node": "3.378.0",
         "@smithy/config-resolver": "^2.0.1",
@@ -313,22 +312,22 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.379.1.tgz",
-      "integrity": "sha512-gEnKuk9bYjThvmxCgOgCn1qa+rRX8IgIRE2+xhbWhlpDanozhkDq9aMB5moX4tBNYQEmi1LtGD+JOvOoZRnToQ==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.382.0.tgz",
+      "integrity": "sha512-G5wgahrOqmrljjyLVGASIZUXIIdalbCo0z4PuFHdb2R2CVfwO8renfgrmk4brT9tIxIfen5bRA7ftXMe7yrgRA==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.379.1",
+        "@aws-sdk/credential-provider-node": "3.382.0",
         "@aws-sdk/middleware-host-header": "3.379.1",
         "@aws-sdk/middleware-logger": "3.378.0",
         "@aws-sdk/middleware-recursion-detection": "3.378.0",
         "@aws-sdk/middleware-sdk-sts": "3.379.1",
         "@aws-sdk/middleware-signing": "3.379.1",
-        "@aws-sdk/middleware-user-agent": "3.379.1",
+        "@aws-sdk/middleware-user-agent": "3.382.0",
         "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.378.0",
+        "@aws-sdk/util-endpoints": "3.382.0",
         "@aws-sdk/util-user-agent-browser": "3.378.0",
         "@aws-sdk/util-user-agent-node": "3.378.0",
         "@smithy/config-resolver": "^2.0.1",
@@ -361,12 +360,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.379.1.tgz",
-      "integrity": "sha512-29X4nxo+47TeENgCpaTeMaK66cn7Uv7Fo4HPvGoevtWljqMqlSSNwQgmvpvqkQWGNtG6Ma/7GXkPMBuoqpwC8g==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.382.0.tgz",
+      "integrity": "sha512-fEsmPSylpQdALSS1pKMa9QghMk9xFiQCanmUWbQ7ETkcjuYuc/DK6GIA0pRjq/BROJJNSxKrSxt3TZPzVpvb3w==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.379.1",
+        "@aws-sdk/client-cognito-identity": "3.382.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/types": "^2.0.2",
@@ -392,14 +391,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.379.1.tgz",
-      "integrity": "sha512-YhEsJIskzCFwIIKiMN9GSHQkgWwj/b7rq0ofhsXsCRimFtdVkmMlB9veE6vtFAuXpX/WOGWdlWek1az0V22uuw==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.382.0.tgz",
+      "integrity": "sha512-31pi44WWri2WQmagqptUv7x3Nq8pQ6H06OCQx5goEm77SosSdwQwyBPrS9Pg0yI9aljFAxF+rZ75degsCorbQg==",
       "optional": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.378.0",
         "@aws-sdk/credential-provider-process": "3.378.0",
-        "@aws-sdk/credential-provider-sso": "3.379.1",
+        "@aws-sdk/credential-provider-sso": "3.382.0",
         "@aws-sdk/credential-provider-web-identity": "3.378.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/credential-provider-imds": "^2.0.0",
@@ -413,15 +412,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.379.1.tgz",
-      "integrity": "sha512-39Y4OHKn6a8lY8YJhSLLw08aZytWxfvSjM4ObIEnE6hjLl8gsL9vROKKITsh3q6iGQ1EDSWMWZL50aOh3LJUIg==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.382.0.tgz",
+      "integrity": "sha512-q6AWCCb0E0cH/Y5Dtln0QssbCBXDbV4PoTV3EdRuGoJcHyNfHJ8X0mqcc7k44wG4Piazu+ufZThvn43W7W9a4g==",
       "optional": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.378.0",
-        "@aws-sdk/credential-provider-ini": "3.379.1",
+        "@aws-sdk/credential-provider-ini": "3.382.0",
         "@aws-sdk/credential-provider-process": "3.378.0",
-        "@aws-sdk/credential-provider-sso": "3.379.1",
+        "@aws-sdk/credential-provider-sso": "3.382.0",
         "@aws-sdk/credential-provider-web-identity": "3.378.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/credential-provider-imds": "^2.0.0",
@@ -451,13 +450,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.379.1.tgz",
-      "integrity": "sha512-PhGtu1+JbUntYP/5CSfazQhWsjUBiksEuhg9fLhYl5OAgZVjVygbgoNVUz/gM7gZJSEMsasTazkn7yZVzO/k7w==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.382.0.tgz",
+      "integrity": "sha512-tKCQKqxnAHeRD7pQNmDmLWwC7pt5koo6yiQTVQ382U+8xx7BNsApE1zdC4LrtrVN1FYqVbw5kXjYFtSCtaUxGA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.379.1",
-        "@aws-sdk/token-providers": "3.379.1",
+        "@aws-sdk/client-sso": "3.382.0",
+        "@aws-sdk/token-providers": "3.382.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
@@ -484,20 +483,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.379.1.tgz",
-      "integrity": "sha512-srPdRQmavvWAwtrlYqo5GaIhIH0bhMl0knzxIDUf81aBfitNKACWwnbML7TpL/dWSPH2b7ciOBWneK1o1GKNLg==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.382.0.tgz",
+      "integrity": "sha512-+emgPCb8t5ODLpE1GeCkKaI6lx9M3RLQCYBGYkm/2o8FyvNeob9IBs6W8ufUTlnl4YRdKjDOlcfDtS00wCVHfA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.379.1",
-        "@aws-sdk/client-sso": "3.379.1",
-        "@aws-sdk/client-sts": "3.379.1",
-        "@aws-sdk/credential-provider-cognito-identity": "3.379.1",
+        "@aws-sdk/client-cognito-identity": "3.382.0",
+        "@aws-sdk/client-sso": "3.382.0",
+        "@aws-sdk/client-sts": "3.382.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.382.0",
         "@aws-sdk/credential-provider-env": "3.378.0",
-        "@aws-sdk/credential-provider-ini": "3.379.1",
-        "@aws-sdk/credential-provider-node": "3.379.1",
+        "@aws-sdk/credential-provider-ini": "3.382.0",
+        "@aws-sdk/credential-provider-node": "3.382.0",
         "@aws-sdk/credential-provider-process": "3.378.0",
-        "@aws-sdk/credential-provider-sso": "3.379.1",
+        "@aws-sdk/credential-provider-sso": "3.382.0",
         "@aws-sdk/credential-provider-web-identity": "3.378.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/credential-provider-imds": "^2.0.0",
@@ -587,13 +586,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.379.1.tgz",
-      "integrity": "sha512-4zIGeAIuutcRieAvovs82uBNhJBHuxfxaAUqrKiw49xUBG7xeNVUl+DYPSpbALbEIy4ujfwWCBOOWVCt6dyUZg==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.382.0.tgz",
+      "integrity": "sha512-LFRW1jmXOrOAd3911ktn6oaYmuurNnulbdRMOUdwz99GGdLVFipQhOi9idKswb8IOhPa4jEVQt25Kcv7ctvu0A==",
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.378.0",
+        "@aws-sdk/util-endpoints": "3.382.0",
         "@smithy/protocol-http": "^2.0.1",
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
@@ -603,12 +602,12 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.379.1.tgz",
-      "integrity": "sha512-NlYPkArJ7A/txCrjqqkje+4hsv7pSOqm+Qdx3BUIOc7PRYrBVs/XwThxUkGceSntVXoNlO8g9DFL0NY53/wb8Q==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.382.0.tgz",
+      "integrity": "sha512-axn4IyPpHdkXi8G06KCB3tPz79DipZFFH9N9YVDpLMnDYTdfX36HGdYzINaQc+z+XPbEpa1ZpoIzWScHRjFjdg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.379.1",
+        "@aws-sdk/client-sso-oidc": "3.382.0",
         "@aws-sdk/types": "3.378.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
@@ -633,9 +632,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.378.0.tgz",
-      "integrity": "sha512-NU5C2l2xAXxpyB5nT0fIhahLPlJoJdzHWw4uC53KH9b4PrjHtgvgCN8beIsD3QxyfgeoM4A5J9Auo6WurfRnLw==",
+      "version": "3.382.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.382.0.tgz",
+      "integrity": "sha512-flajPyjmjNG67fXk7l4GoTB/7J11VBqtFZXuuAZKhKU07Ia3IQupsFqNf5lV8D44ZgjnKH0fTGnv3dUALjW7Wg==",
       "optional": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
@@ -5667,12 +5666,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
-      "dev": true
-    },
     "node_modules/bignumber.js": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
@@ -5872,9 +5865,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "dev": true,
       "funding": [
         {
@@ -5891,9 +5884,9 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001503",
-        "electron-to-chromium": "^1.4.431",
-        "node-releases": "^2.0.12",
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
         "update-browserslist-db": "^1.0.11"
       },
       "bin": {
@@ -6022,9 +6015,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001517",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
+      "version": "1.0.30001518",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
+      "integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
       "dev": true,
       "funding": [
         {
@@ -6835,9 +6828,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.3.0.tgz",
-      "integrity": "sha512-7glNLfvdsMzZm3FpRY1CHuI2lbYDR+71YmrhmTZjYFD5pfT0ACgnGRdrrC9Mk2uICnzkcdelCx5at787UDGOvg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
       "dev": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -7065,9 +7058,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.477",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.477.tgz",
-      "integrity": "sha512-shUVy6Eawp33dFBFIoYbIwLHrX0IZ857AlH9ug2o4rvbWmpaCUdBpQ5Zw39HRrfzAFm4APJE9V+E2A/WB0YqJw==",
+      "version": "1.4.480",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.480.tgz",
+      "integrity": "sha512-IXTgg+bITkQv/FLP9FjX6f9KFCs5hQWeh5uNSKxB9mqYj/JXhHDbu+ekS43LVvbkL3eW6/oZy4+r9Om6lan1Uw==",
       "dev": true
     },
     "node_modules/emitter-listener": {
@@ -13804,6 +13797,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ==",
+      "extraneous": true,
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/pm2": {

--- a/server/package.json
+++ b/server/package.json
@@ -45,7 +45,6 @@
     "@babel/runtime": "^7.22.3",
     "@types/jest": "^29.5.3",
     "babel-loader": "^9.1.2",
-    "bcryptjs": "^2.4.3",
     "eslint": "^8.42.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.8.0",

--- a/server/src/controller/auth.js
+++ b/server/src/controller/auth.js
@@ -21,7 +21,7 @@ const googleLogout = async (req, res) => {
       httpOnly: true,
       secure: true,
     });
-    res.redirect(`${SERVER_HOST}/auth/google/callback`);
+    res.redirect(`${SERVER_HOST}/auth/login/google`);
   });
 };
 

--- a/server/src/controller/auth.js
+++ b/server/src/controller/auth.js
@@ -4,7 +4,7 @@ import { ERROR_TYPE, errorGenerator } from '../utils/error.js';
 
 dotenv.config();
 
-const { GOOGLE_CLIENT_ID, SERVER_REDIRECT_URI } = process.env;
+const { SERVER_HOST } = process.env;
 
 const googleLogout = async (req, res) => {
   const expirationDate = addSeconds(new Date(), 1);
@@ -13,13 +13,15 @@ const googleLogout = async (req, res) => {
       errorGenerator(ERROR_TYPE.NETWORK_ERROR);
     }
     req.session.passport = null;
-    res.clearCookie('connect.sid', { path: '/auth/login/google' });
+    res.clearCookie('connect.sid', {
+      path: `${SERVER_HOST}/auth/login/google`,
+    });
     res.cookie('connect.sid', '', {
       expires: expirationDate,
       httpOnly: true,
       secure: true,
     });
-    res.redirect('/auth/login/google');
+    res.redirect(`${SERVER_HOST}/auth/google/callback`);
   });
 };
 

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -4,7 +4,15 @@ import { getUserInfoByEmail } from '../models/user.js';
 import { users } from '../data/data.js';
 import generateToken from '../utils/token.js';
 
-const { FRONT_URL_DEPLOYED, FRONT_URL, TEST_USER_EMAIL, PROD } = process.env;
+const {
+  SERVER_HOST,
+  FRONT_URL_DEPLOYED,
+  FRONT_URL,
+  TEST_USER_EMAIL,
+  PROD,
+  SECRET_KEY,
+  AUTH,
+} = process.env;
 
 const REDIRECT_URL = PROD === 'on' ? FRONT_URL_DEPLOYED : FRONT_URL;
 
@@ -18,7 +26,7 @@ export const isLoggedIn = (req, res, next) => {
 };
 
 export const isNotLoggedIn = (req, res, next) => {
-  if (process.env.AUTH !== 'on') {
+  if (AUTH !== 'on') {
     const token = generateToken(TEST_USER_EMAIL);
     return res.redirect(301, `${REDIRECT_URL}?token=${token}`);
   }
@@ -30,17 +38,17 @@ export const isNotLoggedIn = (req, res, next) => {
 };
 
 export const verifyToken = async (req, res, next) => {
-  if (process.env.AUTH !== 'on') {
+  if (AUTH !== 'on') {
     req.user = users.find(user => user.email === TEST_USER_EMAIL);
     next();
   } else {
     try {
       const token = req.headers.authorization.split(' ')[1];
-      console.log('verifyTone ', token);
+      //console.log('verifyToken ', token);
       if (!token) {
         return res.status(401).json({ url: REDIRECT_URL });
       }
-      const decodedToken = jwt.verify(token, process.env.SECRET_KEY);
+      const decodedToken = jwt.verify(token, SECRET_KEY);
       const { email } = decodedToken;
       //const email = req.session.passport.user;
       const user = await getUserInfoByEmail(email);
@@ -61,18 +69,16 @@ export const verifyToken = async (req, res, next) => {
   }
 };
 export const verifyToken2 = async (req, res, next) => {
-  if (process.env.AUTH !== 'on') {
+  if (AUTH !== 'on') {
     req.user = users.find(user => user.email === TEST_USER_EMAIL);
     next();
   } else {
     try {
-      console.log('req.session : ', req.session);
-      console.log('req.session passport: ', req.session.passport);
       if (!(req.session.passport && req.isAuthenticated())) {
         return res.status(401).json({ url: REDIRECT_URL });
       }
       const token = req.session.passport.user;
-      const decodedToken = jwt.verify(token, process.env.SECRET_KEY);
+      const decodedToken = jwt.verify(token, SECRET_KEY);
       const { email } = decodedToken;
       //const email = req.session.passport.user;
       const user = await getUserInfoByEmail(email);
@@ -99,7 +105,7 @@ export const googleCallback2 = (req, res, next) => {
       return next(err);
     }
     if (!user) {
-      return res.redirect('/auth/login/google');
+      return res.redirect(`${SERVER_HOST}/auth/login/google`);
     }
     req.logIn(user, err => {
       if (err) {
@@ -118,7 +124,7 @@ export const googleCallback = (req, res, next) => {
     if (err) {
       console.error(err);
     } else if (!user) {
-      res.redirect('/auth/login/google');
+      res.redirect(`${SERVER_HOST}/auth/login/google`);
     } else {
       req.logIn(user, err => {
         if (err) {

--- a/server/src/middleware/googleStrategy.js
+++ b/server/src/middleware/googleStrategy.js
@@ -9,7 +9,7 @@ dotenv.config();
 const GOOGLE_OAUTH_OPTION = {
   clientID: process.env.GOOGLE_CLIENT_ID,
   clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-  callbackURL: '/auth/google/callback',
+  callbackURL: `${process.env.SERVER_HOST}/auth/google/callback`,
   scope: ['email', 'profile'],
   passReqToCallback: true,
 };

--- a/server/src/middleware/googleStrategy.js
+++ b/server/src/middleware/googleStrategy.js
@@ -6,10 +6,12 @@ import generateToken from '../utils/token.js';
 
 dotenv.config();
 
+const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, SERVER_HOST } = process.env;
+
 const GOOGLE_OAUTH_OPTION = {
-  clientID: process.env.GOOGLE_CLIENT_ID,
-  clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-  callbackURL: `${process.env.SERVER_HOST}/auth/google/callback`,
+  clientID: GOOGLE_CLIENT_ID,
+  clientSecret: GOOGLE_CLIENT_SECRET,
+  callbackURL: `${SERVER_HOST}/auth/google/callback`,
   scope: ['email', 'profile'],
   passReqToCallback: true,
 };

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -58,8 +58,6 @@ const whitelist = corslist
   .concat(deployableUrls)
   .filter(item => item !== undefined && item !== null && item !== '')
   .filter((value, index, self) => self.indexOf(value) === index);
-
-
 const corsOptions = {
   origin: whitelist,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
@@ -84,7 +82,7 @@ app.use(passport.initialize());
 app.use(passport.authenticate('session'));
 passportConfig();
 app.use(limiter);
-app.use(routes);
+app.use('/api', routes);
 
 app.get('/ping', (req, res) => {
   res.json({ message: 'pong' });


### PR DESCRIPTION
## :: Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Edit convention

<br />

## :: Description
- add endpoint prefix 'api' to support running client and server on same server
- .env updated: [notion](https://www.notion.so/thekimsplustwo/env-1338bb37ffa145359c6ed75a11cd87eb?pvs=4)
  - client/.env :  REACT_APP_BASE_URL needs to include 'api'
  - server/.env: SERVER_HOST needs to include 'api'
<br />
