### PR TITLE
ISSUE-283: detailed page data displaying

### DIFF
--- a/client/src/components/Property/DetailedInfo.js
+++ b/client/src/components/Property/DetailedInfo.js
@@ -20,8 +20,17 @@ function InfoRowComponent({ icon, label, value, unit }) {
 
   return (
     <InfoRow>
-      <StyledIcon style={{ marginBottom: '-5px' }} sx={{ color: '#ff385c' }} />
-      <Bold>{label}: </Bold> {value} {unit}
+      <StyledIcon
+        style={{ marginBottom: '-5px' }}
+        sx={{
+          color: '#ff385c',
+          opacity: '0.7',
+          padding: '0.3rem',
+          fontSize: '2rem',
+          marginRight: '1rem',
+        }}
+      />
+      <Bold>{label}: </Bold> {value || 'N/A'} {value && unit ? unit : ''}
     </InfoRow>
   );
 }
@@ -79,6 +88,7 @@ function DetailedInfo({ propertyDetails }) {
                     icon={AutoAwesomeIcon}
                     label="House Age"
                     value={new Date().getFullYear() - yearBuilt}
+                    unit="year"
                   />
                   <InfoRowComponent
                     icon={CropFreeRoundedIcon}
@@ -159,7 +169,8 @@ function DetailedInfo({ propertyDetails }) {
           >
             <StyledText>
               <InfoRow>
-                <BoldHeader>Overview </BoldHeader> {description}
+                <BoldHeader>Overview </BoldHeader>
+                <DescriptionWrapper>{description}</DescriptionWrapper>
               </InfoRow>
             </StyledText>
           </div>
@@ -173,7 +184,7 @@ export default DetailedInfo;
 const InfoRow = styled.p`
   margin-bottom: 10px;
   ${baseInfoRowStyles}
-
+  letter-spacing: 0.08em;
   @media (max-width: 600px) {
     font-size: 0.8rem;
   }
@@ -223,4 +234,10 @@ const Box = styled.div`
   font-weight: bold;
   border-radius: 10px;
   box-shadow: 10px 10px #fbe8e9;
+`;
+
+const DescriptionWrapper = styled.div`
+  letter-spacing: 0.1em;
+  word-spacing: 0.2em;
+  line-height: 2.1em;
 `;


### PR DESCRIPTION
## :: Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Edit convention

<br />

## :: Description
- detailed page data displaying
- hide value and unit if value is undefined
<br />

## :: Screenshoot

![Screenshot 2023-08-06 at 4 48 36 PM](https://github.com/thekimsplustwo/VanCityPropertyPulse/assets/67996710/96eb32ae-9557-4e8e-ba3f-79a30a5403ee)


@chris718 please add your fix if you have any updates. Thanks!