### PR TITLE
ISSUE-312: Fix the Issues for Nearby Me + Nearby Homes

### DIFF
--- a/client/src/components/User/NearbyMe.js
+++ b/client/src/components/User/NearbyMe.js
@@ -25,13 +25,22 @@ function NearbyMe({ region }) {
   }, [dispatch, region]);
 
   const properties = useSelector(state => state.home.list);
-  const filteredProperties = properties.filter(
-    property => property.listingStatus === 'FOR_SALE'
-  );
-  const limitedProperties =
-    filteredProperties.length >= 10
-      ? filteredProperties.slice(0, 10)
-      : filteredProperties;
+  let filteredProperties = [];
+  if (region === '') {
+    filteredProperties = [];
+  } else {
+    filteredProperties = properties.filter(
+      property => property.listingStatus === 'FOR_SALE'
+    );
+  }
+  let limitedProperties = [];
+  if (properties.length !== 0) {
+    if (filteredProperties && filteredProperties.length >= 10) {
+      limitedProperties = filteredProperties.slice(0, 10);
+    } else {
+      limitedProperties = filteredProperties;
+    }
+  }
 
   const adaptHomeData = homeData => {
     return {

--- a/client/src/pages/PropertyDetail/PropertyDetail.js
+++ b/client/src/pages/PropertyDetail/PropertyDetail.js
@@ -41,9 +41,9 @@ function Property() {
 
   if (isObjectValid(property)) {
     const { nearbyHomes, longitude, latitude } = property;
-    const filteredNearbyHomes = nearbyHomes.filter(
-      home => home.homeStatus === 'FOR_SALE'
-    );
+    // const filteredNearbyHomes = nearbyHomes.filter(
+    //   home => home.homeStatus === 'FOR_SALE'
+    // );
     return (
       <Wrapper>
         <HeaderWrapper>
@@ -65,7 +65,7 @@ function Property() {
         <Divider sx={{ borderBottomWidth: 4 }} />
         <AdditionalInfo propertyDetails={property} transit={transitScore} />
         <Divider sx={{ borderBottomWidth: 4 }} />
-        <NearByHomes nearbyHomes={filteredNearbyHomes} />
+        <NearByHomes nearbyHomes={nearbyHomes} />
         <Divider sx={{ borderBottomWidth: 4 }} />
         <WalkScore zpid={zpid} />
       </Wrapper>

--- a/client/src/redux/home/reducer.js
+++ b/client/src/redux/home/reducer.js
@@ -27,6 +27,7 @@ const homeSlice = createSlice({
       })
       .addCase(getListAsync.rejected, (state, action) => {
         state.getList = REQUEST_STATE.REJECTED;
+        state.list = [];
         state.error = action.error;
       });
   },


### PR DESCRIPTION
## :: Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Edit convention

<br />

## :: Description

- Nearby Me doesn't render the previous list when the user's region is either empty or invalid
- Nearby Homes back to its original state before the filtering feature was implemented

![image](https://github.com/thekimsplustwo/VanCityPropertyPulse/assets/104828095/98123fa2-4334-410d-9438-4bf6bfb9d627)

<br />
