### PR TITLE
ISSUE-331: Refresh the page after user updates their profile info

### DIFF
--- a/client/src/components/User/UserProfileEdit.js
+++ b/client/src/components/User/UserProfileEdit.js
@@ -1,15 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import { TextField, Button, MenuItem } from '@mui/material';
 import { editProfileAsync } from '../../redux/users/thunks';
-import { FRONT_LOGIN_URL } from '../../config';
 import { neighborhoodsVancouver } from '../SearchOption/neighborhoods';
 
 function UserProfileEdit({ setModal }) {
   const token = localStorage.getItem('token');
   const user = useSelector(state => state.users.user);
+
   const dispatch = useDispatch();
+
   const [formData, setFormData] = useState({
     firstName: user.firstName ?? '',
     lastName: user.lastName || '',
@@ -37,7 +38,7 @@ function UserProfileEdit({ setModal }) {
   const handleSaveBtn = () => {
     dispatch(editProfileAsync({ formData, token }));
     setModal(false);
-    window.location.href = `${FRONT_LOGIN_URL}/mypage`;
+    window.location.reload(false);
   };
 
   return (

--- a/client/src/pages/MyPage/MyPage.js
+++ b/client/src/pages/MyPage/MyPage.js
@@ -12,9 +12,11 @@ import NearbyMe from '../../components/User/NearbyMe';
 
 function MyPage() {
   const token = localStorage.getItem('token');
-  const navigate = useNavigate();
   const [modal, setModal] = useState(false);
+
+  const navigate = useNavigate();
   const dispatch = useDispatch();
+
   const isLogin = useSelector(state => state.users.isLogin);
   const navigateToLogin = () => {
     navigate('/');


### PR DESCRIPTION
## :: Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Edit convention

<br />

## :: Description

- `window.location.reload()` is used instead of assigning the path to `window.location.href`.
- Tried using `useNavigate()` and `useEffect()`, but wasn't successful. Would like to first see how this version works in the deployed app.

<br />
